### PR TITLE
Console height detection

### DIFF
--- a/src/ConsoleColorOutput/ConsoleColorOutput/ConsoleOutputHelper.cs
+++ b/src/ConsoleColorOutput/ConsoleColorOutput/ConsoleOutputHelper.cs
@@ -9,6 +9,7 @@ namespace ConsoleColorOutput {
 
 		public void WriteLine(string originalText) {
 			int consoleWidth = Console.BufferWidth;
+			int consoleHeight = Console.WindowHeight;
 			
 			var currentLine = new StringBuilder(120);
 
@@ -29,9 +30,11 @@ namespace ConsoleColorOutput {
 						if (currentLine.Length > 0 || charsInLine > 0) {
 							System.Console.WriteLine(currentLine.ToString());
 							linesWritten++;
+							PauseAfterScreenful();
 
 							System.Console.WriteLine();
 							linesWritten++;
+							PauseAfterScreenful();
 
 							currentLine.Clear();
 							charsInLine = 0;
@@ -47,6 +50,7 @@ namespace ConsoleColorOutput {
 						Console.WriteLine(line);
 						linesWritten++;
 						ResetColor();
+						PauseAfterScreenful();
 						continue;
 					}
 
@@ -101,6 +105,7 @@ namespace ConsoleColorOutput {
 				if (newLine) {
 					System.Console.WriteLine(currentLine.ToString());
 					linesWritten++;
+					PauseAfterScreenful();
 					charsInLine = 0;
 				}
 				else {
@@ -109,6 +114,16 @@ namespace ConsoleColorOutput {
 				}
 				currentLine.Clear();
 			}
+			
+			void PauseAfterScreenful() {
+				if (linesWritten - lastPause + 2 > consoleHeight) {
+					lastPause = linesWritten;
+					System.Console.Write("--more--");
+					System.Console.ReadKey();
+					System.Console.Write("\r            \r");
+				}
+			}
+
 		}
 
 		private static void ResetColor() {

--- a/src/ConsoleColorOutput/TestCCO/Program.cs
+++ b/src/ConsoleColorOutput/TestCCO/Program.cs
@@ -27,42 +27,42 @@ accordingly.");
 			ou.WriteLine(@"So let's color {cyan}something{} in the middle.");
 
 			// Fifth test case
-			ou.WriteLine(@"When we are creating many text.
+			ou.WriteLine(@"1 When we are creating many text.
 
-And I mean many.
+2 And I mean many.
 
-Many {yellow}many{} many.
+3 Many {yellow}many{} many.
 
-We want this to pause when the console is full. 
+4 We want this to pause when the console is full. 
 
-Or display.
+5 Or display.
 
-Whatever.
+6 Whatever.
 
-More text here.
+7 More text here.
 
-More text here.
+8 More text here.
 
-More text here.
+9 More text here.
 
-More text here.
+10 More text here.
 
-More text here.
+11 More text here.
 
-More text here.
+12 More text here.
 
-More text here.
+13 More text here.
 
-More text here.
+14 More text here.
 
+15 More text here. More text here. More text here. More text here. More text here. More text here. More text here.
 More text here. More text here. More text here. More text here. More text here. More text here. More text here.
-More text here. More text here. More text here. More text here. More text here. More text here. More text here.
 
-More text here.
+16 More text here.
 
-More text here.
+17 More text here.
 
-");
+18 that should be enough. {green}DONE{}.");
         }
     }
 }


### PR DESCRIPTION
First stab at an output line detection. This will will show --more-- and wait for a keypress to show more lines. 

While this works, it works only for a single output. This was a problem with my game as well. If I print two long things one after the other, but neither would individually cause a pause, they will both just display. 

But solving this needs more thought  - buffering until output is ready, etc.